### PR TITLE
fix: grep version output

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.14
       id: go
 
     - name: Check out code

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ You can provide the current version by defining an environment variable `VERSION
 ```bash
 export VERSION=4.0.7
 ```
+
 If the environment variable is not found, git tags will be checked to see if they contain a version string as defined at https://semver.org/
 
 To determine the type of change, the latest commit message will be checked for the following keywords:

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module semtag
 
-go 1.13
+go 1.14

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
 	"os"
 	"strings"
@@ -75,14 +76,14 @@ func getVersions() (*version.Version, *version.Version) {
 	v.Suffix = suffix
 	v.Prefix = prefix
 	v = *v.GetLatest()
-	log.Println("version:", v.String())
+	fmt.Println("version:", v.String())
 	if skipInc {
 		log.Println("skip version increment: flag set by user")
 		return &v, &v
 	}
 	nextV = *v.GetLatest()
 	nextV.IncrementAuto()
-	log.Println("next version:", nextV.String())
+	fmt.Println("next-version:", nextV.String())
 	return &v, &nextV
 }
 


### PR DESCRIPTION
The underlying code behind log.Println() uses fmt.Sprintln() (see https://golang.org/src/log/log.go?s=8792:8822#L284) while fmt.Println() uses Fprintln() function. (see https://golang.org/src/fmt/print.go?s=7388:7437#L246)

Upgrade go version