### PR TITLE
feat!: version multiple components in the same repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL = /bin/bash
 
 all: | test build
 
-build:
+build: | test
 	go build -o out/semtag
 
 test:

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ A `feat`ure increments the minor number, and resets the patch number to zero (e.
 
 All other types increment the patch number (e.g. 4.0.7 -> 4.0.8)
 
+Note: You can have separate tracking by Git tags for multiple components in a repo
+
 
 
 ## Docs

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -9,6 +9,7 @@ example:
 # existing git tag: v3.0.28
 
 ./semtag -git-tag -increment -prefix v
+git push
 ```
 > 2019/09/14 23:41:29 current version: v3.0.28
 <br>2019/09/14 23:41:29 next version: v3.0.29
@@ -19,6 +20,43 @@ example:
 <br>Total 1 (delta 0), reused 0 (delta 0)
 <br>To REDACTED.git
 <br> * [new tag]         v3.0.29 -> v3.0.29
+
+
+## add new Git tags for multiple unrelated components in the same repository
+For multiple unrelated components in the same repository, use a combination of `-prefix` and `-suffix` flags; you only need to have a unique tagging format so one flag is enough.
+```bash
+# existing git tags:
+#   v3.0.28-api
+#   v3.1.12-web
+
+./semtag -git-tag -increment -prefix v -suffix -api
+```
+> 2019/09/14 23:41:29 current version: v3.0.28-api
+<br>2019/09/14 23:41:29 next version: v3.0.29-api
+<br>2019/09/14 23:41:30 &{v3.0.29-api v3.0.28-api-2-gf65a7df-20190914204130}
+>
+> Counting objects: 1, done.
+<br>Writing objects: 100% (1/1), 176 bytes | 176.00 KiB/s, done.
+<br>Total 1 (delta 0), reused 0 (delta 0)
+<br>To REDACTED.git
+<br> * [new tag]         v3.0.29-api -> v3.0.29-api
+```bash
+# existing git tags:
+#   v3.0.29-api
+#   v3.1.12-web
+
+./semtag -git-tag -increment -prefix v -suffix -web
+```
+> 2019/09/14 23:42:16 current version: v3.1.12-web
+<br>2019/09/14 23:42:16 next version: v3.1.13-web
+<br>2019/09/14 23:42:17 &{v3.1.13-web v3.1.12-1-d8111g97-20190914204217}
+>
+> Counting objects: 1, done.
+<br>Writing objects: 100% (1/1), 176 bytes | 176.00 KiB/s, done.
+<br>Total 1 (delta 0), reused 0 (delta 0)
+<br>To REDACTED.git
+<br> * [new tag]         v3.1.13-web -> v3.1.13-web
+
 
 
 # update a version string in a file

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -30,6 +30,7 @@ For multiple unrelated components in the same repository, use a combination of `
 #   v3.1.12-web
 
 ./semtag -git-tag -increment -prefix v -suffix -api
+git push
 ```
 > 2019/09/14 23:41:29 current version: v3.0.28-api
 <br>2019/09/14 23:41:29 next version: v3.0.29-api

--- a/pkg/docker/main.go
+++ b/pkg/docker/main.go
@@ -1,7 +1,6 @@
 package docker
 
 import (
-	"fmt"
 	"log"
 
 	"semtag/pkg"
@@ -12,7 +11,7 @@ func Load(tarFile string) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Println(out)
+	log.Println(out)
 }
 
 func Tag(image string, remoteImage string) {
@@ -20,7 +19,7 @@ func Tag(image string, remoteImage string) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Println(out)
+	log.Println(out)
 }
 
 func Push(image string) {
@@ -28,5 +27,5 @@ func Push(image string) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Println(out)
+	log.Println(out)
 }

--- a/pkg/git/config.go
+++ b/pkg/git/config.go
@@ -1,7 +1,6 @@
 package git
 
 import (
-	"fmt"
 	"log"
 	"os"
 
@@ -19,7 +18,7 @@ func trySetGitConfigUserAndEmail() {
 	gitUsername, isGitUser := os.LookupEnv("GIT_USERNAME")
 	if !(isGitEmail && isGitUser) {
 		if pkg.DEBUG != "" {
-			fmt.Println("skip setting git email and username: at least one environment variable is missing ['GIT_EMAIL, GIT_USERNAME']")
+			log.Println("skip setting git email and username: at least one environment variable is missing ['GIT_EMAIL, GIT_USERNAME']")
 		}
 		return
 	}
@@ -40,7 +39,7 @@ func trySetGitCredentialsSshKey() {
 	sshKey, isSshKey := os.LookupEnv("GIT_SSH_KEY_PRIVATE")
 	if !(isHost && isProjectPath && isSshKey) {
 		if pkg.DEBUG != "" {
-			fmt.Println("skip setting git to work on SSH: at least one environment variable is missing ['GIT_HOSTNAME, GIT_PROJECT_PATH, GIT_SSH_KEY_PRIVATE']")
+			log.Println("skip setting git to work on SSH: at least one environment variable is missing ['GIT_HOSTNAME, GIT_PROJECT_PATH, GIT_SSH_KEY_PRIVATE']")
 		}
 		return
 	}
@@ -74,7 +73,7 @@ func trySetGitCredentialsSshKey() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Println("changed git global push url: HTTPS -> SSH")
+	log.Println("changed git global push url: HTTPS -> SSH")
 }
 
 func trySetGitCredentialsBasicAuth() {
@@ -87,5 +86,5 @@ func trySetGitCredentialsBasicAuth() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Printf("add to git credential.helper: %s, $GIT_PASSWORD\n", gitUsername)
+	log.Printf("add to git credential.helper: %s, $GIT_PASSWORD\n", gitUsername)
 }

--- a/pkg/git/main.go
+++ b/pkg/git/main.go
@@ -1,7 +1,6 @@
 package git
 
 import (
-	"fmt"
 	"log"
 	"strconv"
 	"strings"
@@ -14,7 +13,7 @@ func Commit(msg string) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Println(out)
+	log.Println(out)
 }
 
 func Add(file string) {
@@ -22,19 +21,19 @@ func Add(file string) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Println(out)
+	log.Println(out)
 }
 
 func Push(target string) {
 	if target == "" {
 		target = "--all"
-		fmt.Println("no target specified; use default target:", target)
+		log.Println("no target specified; use default target:", target)
 	}
 	out, err := pkg.Shell("git push origin " + target)
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Println(out)
+	log.Println(out)
 }
 
 func Tag(tag string, message string) {
@@ -42,7 +41,7 @@ func Tag(tag string, message string) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Println(out)
+	log.Println(out)
 }
 
 func RevParse() string {
@@ -63,8 +62,16 @@ func DescribeLong() string {
 	return out
 }
 
-func GetLatestTag() (*string, error) {
-	out, err := pkg.Shell(`git describe --tags $(git rev-list --tags --max-count=1)`)
+func GetLatestTag(prefix string, suffix string) (*string, error) {
+	cmd := "git tag"
+	if prefix != "" {
+		cmd += "| grep -i -e " + prefix
+	}
+	if suffix != "" {
+		cmd += "| grep -i -e " + suffix
+	}
+	cmd += "| sort -rn | head -1"
+	out, err := pkg.Shell(cmd)
 	return &out, err
 }
 
@@ -88,5 +95,5 @@ func Fetch() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Println(out)
+	log.Println(out)
 }

--- a/pkg/os.go
+++ b/pkg/os.go
@@ -2,6 +2,7 @@ package pkg
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"strings"
@@ -13,12 +14,12 @@ func Shell(cmd string) (string, error) {
 	const ShellToUse = "bash"
 	c := exec.Command(ShellToUse, "-c", cmd)
 	if DEBUG != "" {
-		fmt.Println(c.Args)
+		log.Println(c.Args)
 	}
 	c.Stderr = os.Stderr
 	out, err := c.Output()
 	if DEBUG != "" {
-		fmt.Println(string(out))
+		log.Println(string(out))
 	}
 	return strings.Replace(string(out), "\n", "", -1), err
 }


### PR DESCRIPTION
Add ability to create new Git tags for multiple unrelated components in the same repository
Search for the combination of `-prefix` and `-suffix` to determine the latest tag

BREAKING CHANGE: Remove `-dry-run` flag and add `-push` flag
Only create Git tags or push when the `-push` flag is set

Revert to using `log.Println` instead of `fmt.Println`

Set some logs to be displayed only if the Debug mode is enabled