### PR TITLE
feat: add ability to specify required file changes for git tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ test:
 
 tag:
 	git config --list | grep "user.email" || git config --global user.email "ci@foo.com" && git config --global user.name "ci"
-	./out/semtag -increment auto -git-tag -prefix "v" -push
+	./out/semtag -increment=auto -git-tag -prefix="v" -push -path=main.go -path=go.mod -path=internal -path=pkg
 
 upload:
 	cp -v out/semtag out/semtag-$$(git describe --tags `git rev-list --tags --max-count=1` | cut -d '.' -f1)

--- a/internal/actions.go
+++ b/internal/actions.go
@@ -10,35 +10,6 @@ import (
 	"semtag/pkg/version"
 )
 
-func GetVersion(args CliArgs) version.Version {
-	var v version.Version
-	if args.CustomVersion != "" {
-		v = getVersionFromUser(args.CustomVersion, args.Prefix, args.Suffix)
-	} else {
-		v = getVersionFromGit(args.Prefix, args.Suffix)
-	}
-	output.Debug(v.String())
-	return v
-}
-
-func getVersionFromUser(customVersion string, prefix string, suffix string) version.Version {
-	var v version.Version
-	v.Suffix = suffix
-	v.Prefix = prefix
-	v.Parse(customVersion)
-	return v
-}
-
-func getVersionFromGit(prefix string, suffix string) version.Version {
-	git.Fetch()
-	var v version.Version
-	v.UseGit = true
-	v.Suffix = suffix
-	v.Prefix = prefix
-	v = *v.GetLatest()
-	return v
-}
-
 func TagGit(ver version.Version, push bool) {
 	if git.IsAlreadyTagged(ver.String()) {
 		log.Fatal("The current commit has already been tagged with ", ver.String())
@@ -89,10 +60,7 @@ func GetChangedFiles() string {
 	commit := git.GetHashShort()
 	out, err := terminal.Shellf("git diff %[1]s~1..%[1]s --name-only", commit)
 	if err != nil {
-		if err == terminal.ErrShellCommand {
-			log.Fatalln(err)
-		}
-		log.Panic(err)
+		log.Fatalln(err)
 	}
 	return out
 }

--- a/internal/cliArgs.go
+++ b/internal/cliArgs.go
@@ -9,7 +9,8 @@ import (
 )
 
 const (
-	EmptyStringFlag = ""
+	EmptyStringFlag     = ""
+	DefaultRelevantPath = "./"
 )
 
 var (
@@ -35,7 +36,7 @@ type CliArgs struct {
 type relevantPaths []string
 
 func (i *relevantPaths) String() string {
-	return "my string representation"
+	return DefaultRelevantPath
 }
 
 func (i *relevantPaths) Set(value string) error {
@@ -97,11 +98,6 @@ func (args *CliArgs) ParseFlags() {
 `)
 	flag.Parse()
 
-	if len(args.RelevantPaths) == 0 {
-		args.RelevantPaths = relevantPaths{
-			".",
-		}
-	}
 	if (args.FilePath == EmptyStringFlag) != (args.FileVersionPattern == EmptyStringFlag) {
 		log.Fatalln(ErrOnlyOneDeployFileFlagsSet)
 	}

--- a/internal/cliArgs.go
+++ b/internal/cliArgs.go
@@ -1,18 +1,110 @@
 package internal
 
-import "semtag/pkg/version"
+import (
+	"errors"
+	"flag"
+	"log"
+
+	"semtag/pkg/version"
+)
+
+const (
+	EmptyStringFlag = ""
+)
+
+var (
+	ErrOnlyOneDeployFileFlagsSet = errors.New("to update a file please use both the '-file' and the '-file-pattern' flags")
+)
 
 type CliArgs struct {
 	Prefix        string
 	Suffix        string
 	CustomVersion string
+	VersionScope  version.Scope
 
-	Push         bool
-	VersionScope version.Scope
+	RelevantPaths relevantPaths
 
+	Push           bool
 	ShouldTagGit   bool
-	FilePath       string
-	FileVerPattern string
-
 	ExecuteCommand string
+
+	FilePath           string
+	FileVersionPattern string
+}
+
+type relevantPaths []string
+
+func (i *relevantPaths) String() string {
+	return "my string representation"
+}
+
+func (i *relevantPaths) Set(value string) error {
+	*i = append(*i, value)
+	return nil
+}
+
+func (args *CliArgs) ParseFlags() {
+
+	flag.StringVar(&args.Prefix, "prefix", "", `if set, append the prefix to the version number
+		e.g.:
+		input: ./semtag -prefix='api-'
+		output: api-0.1.0`)
+	flag.StringVar(&args.Suffix, "suffix", "", `if set, append the suffix to the version number
+		e.g.:
+		input: ./semtag -suffix='-rc'
+		output: 0.1.0-rc
+`)
+	flag.StringVar(&args.CustomVersion, "version", "", `if set, use the user-provided version`)
+
+	var versionScope string
+	flag.StringVar(&versionScope, "increment", "", "if set, increment the version scope: auto | major | minor | patch")
+	flag.BoolVar(&args.Push, "push", false, "if set, push the created/updated object(s): push the git tag; add, commit and push the updated file.")
+
+	flag.BoolVar(&args.ShouldTagGit, "git-tag", false, "if set, create an annotated tag")
+
+	flag.StringVar(&args.FilePath, "file", "", `a file that contains the version number (e.g. setup.py)`)
+	flag.StringVar(&args.FileVersionPattern, "file-version-pattern", "", `the pattern expected for the file version
+	e.g.:
+	cat setup.py
+		setup(
+		  name='my-project',
+		  version='3.0.28',
+		)
+
+	input: ./semtag -increment auto -file=setup.py -file-version-pattern="version='%s',"
+	output:
+	cat setup.py
+		setup(
+		  name='my-project',
+		  version='3.1.0',
+		)
+`)
+
+	flag.Var(&args.RelevantPaths, "path",`if set, create a git tag only if changes are detected in the provided path(s)
+	e.g.:
+	input: ./semtag -path="src" -path="lib/" -path="Dockerfile"
+`)
+
+	flag.StringVar(&args.ExecuteCommand, "command", "", `execute a shell command for all version tags: use %s as a placeholder for the version number
+	e.g.:
+	version tags: v5, v5.0, v5.0.3, v5.0.3-32b0262
+	input: ./semtag -prefix='v' -command="docker tag $MY_IMAGE_NAME $MY_DOCKER_REGISTRY/app:%s" 
+	output:
+		sh -c docker tag $MY_IMAGE_NAME $MY_DOCKER_REGISTRY/app:v5
+		sh -c docker tag $MY_IMAGE_NAME $MY_DOCKER_REGISTRY/app:v5.0
+		sh -c docker tag $MY_IMAGE_NAME $MY_DOCKER_REGISTRY/app:v5.0.3
+		sh -c docker tag $MY_IMAGE_NAME $MY_DOCKER_REGISTRY/app:v5.0.3-32b0262
+`)
+	flag.Parse()
+
+	if len(args.RelevantPaths) == 0 {
+		args.RelevantPaths = relevantPaths{
+			".",
+		}
+	}
+	if (args.FilePath == EmptyStringFlag) != (args.FileVersionPattern == EmptyStringFlag) {
+		log.Fatalln(ErrOnlyOneDeployFileFlagsSet)
+	}
+
+	args.VersionScope.Parse(versionScope)
 }

--- a/internal/cliArgs.go
+++ b/internal/cliArgs.go
@@ -80,7 +80,7 @@ func (args *CliArgs) ParseFlags() {
 		)
 `)
 
-	flag.Var(&args.RelevantPaths, "path",`if set, create a git tag only if changes are detected in the provided path(s)
+	flag.Var(&args.RelevantPaths, "path", `if set, create a git tag only if changes are detected in the provided path(s)
 	e.g.:
 	input: ./semtag -path="src" -path="lib/" -path="Dockerfile"
 `)

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"flag"
+	"errors"
 	"fmt"
 	"log"
 
@@ -12,63 +12,13 @@ import (
 	"semtag/pkg/version"
 )
 
-func parseFlags() internal.CliArgs {
-	args := internal.CliArgs{}
-
-	flag.StringVar(&args.Prefix, "prefix", "", `if set, append the prefix to the version number
-		e.g.:
-		input: ./semtag -prefix='api-'
-		output: api-0.1.0`)
-	flag.StringVar(&args.Suffix, "suffix", "", `if set, append the suffix to the version number
-		e.g.:
-		input: ./semtag -suffix='-rc'
-		output: 0.1.0-rc
-`)
-	flag.StringVar(&args.CustomVersion, "version", "", `if set, use the user-provided version`)
-
-	var versionScope string
-	flag.StringVar(&versionScope, "increment", "", "if set, increment the version scope: auto | major | minor | patch")
-	flag.BoolVar(&args.Push, "push", false, "if set, push the created/updated object(s): push the git tag; add, commit and push the updated file.")
-
-	flag.BoolVar(&args.ShouldTagGit, "git-tag", false, "if set, create an annotated tag")
-
-	flag.StringVar(&args.FilePath, "file", "", `a file that contains the version number (e.g. setup.py)`)
-	flag.StringVar(&args.FileVerPattern, "file-version-pattern", "", `the pattern expected for the file version
-	e.g.:
-	cat setup.py
-		setup(
-		  name='my-project',
-		  version='3.0.28',
-		)
-
-	input: ./semtag -increment auto -file=setup.py -file-version-pattern="version='%s',"
-	output:
-	cat setup.py
-		setup(
-		  name='my-project',
-		  version='3.1.0',
-		)
-`)
-
-	flag.StringVar(&args.ExecuteCommand, "command", "", `execute a shell command for all version tags: use %s as a placeholder for the version number
-	e.g.:
-	version tags: v5, v5.0, v5.0.3, v5.0.3-32b0262
-	input: ./semtag -prefix='v' -command="docker tag $MY_IMAGE_NAME $MY_DOCKER_REGISTRY/app:%s" 
-	output:
-		sh -c docker tag $MY_IMAGE_NAME $MY_DOCKER_REGISTRY/app:v5
-		sh -c docker tag $MY_IMAGE_NAME $MY_DOCKER_REGISTRY/app:v5.0
-		sh -c docker tag $MY_IMAGE_NAME $MY_DOCKER_REGISTRY/app:v5.0.3
-		sh -c docker tag $MY_IMAGE_NAME $MY_DOCKER_REGISTRY/app:v5.0.3-32b0262
-`)
-	flag.Parse()
-
-	args.VersionScope.Parse(versionScope)
-
-	return args
-}
+var (
+	ErrNotPushMode = errors.New("push to Git skipped: use the `-push` flag to push changes")
+)
 
 func main() {
-	args := parseFlags()
+	args := internal.CliArgs{}
+	args.ParseFlags()
 
 	v := internal.GetVersion(args)
 
@@ -80,31 +30,34 @@ func main() {
 		fmt.Print(v.String())
 	}
 
+	git.TryConfigureIdentity()
 	git.TrySetGitCredentialsBasicAuth()
 
 	if args.ExecuteCommand != "" {
 		for _, val := range v.AsList() {
 			_, err := terminal.Shellf(args.ExecuteCommand, val)
 			if err == terminal.ErrShellCommand {
-				log.Panic(err)
+				log.Fatal(err)
+			}
+			log.Panic(err)
+		}
+
+	}
+
+	if args.ShouldTagGit {
+		if internal.HasRelevantChanges(args.RelevantPaths) {
+			internal.TagGit(v, args.Push)
+			if !args.Push {
+				output.Debug(ErrNotPushMode)
 			}
 		}
-
 	}
 
-	notPushModeMessage := "push to Git skipped: use the `-push` flag to push changes"
-	if args.ShouldTagGit {
-		internal.TagGit(v, args.Push)
-		if !args.Push {
-			output.Debug(notPushModeMessage)
-		}
-	}
-
-	shouldTagInFile := len(args.FilePath) > 0 && len(args.FileVerPattern) > 0
+	shouldTagInFile := len(args.FilePath) > 0 && len(args.FileVersionPattern) > 0
 	if shouldTagInFile {
-		internal.TagFile(v, args.FilePath, args.FileVerPattern, args.Push)
+		internal.TagFile(v, args.FilePath, args.FileVersionPattern, args.Push)
 		if !args.Push {
-			output.Debug(notPushModeMessage)
+			output.Debug(ErrNotPushMode)
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -38,8 +38,10 @@ func main() {
 		fmt.Print(v.String())
 	}
 
-	git.TryConfigureIdentity()
-	git.TrySetGitCredentialsBasicAuth()
+	if args.Push {
+		git.TryConfigureIdentity()
+		git.TrySetGitCredentialsBasicAuth()
+	}
 
 	if args.ExecuteCommand != "" {
 		for _, val := range v.AsList() {

--- a/main.go
+++ b/main.go
@@ -20,7 +20,12 @@ func main() {
 	args := internal.CliArgs{}
 	args.ParseFlags()
 
-	v := internal.GetVersion(args)
+	v := version.Version{}
+	if args.CustomVersion == internal.EmptyStringFlag {
+		v.GetLatestFromGit()
+	} else {
+		v.UseVersionProvidedByUser(args.Prefix, args.CustomVersion, args.Suffix)
+	}
 
 	shouldIncrementVersion := args.VersionScope.String() != version.EmptyScope
 	if !shouldIncrementVersion {
@@ -36,10 +41,9 @@ func main() {
 	if args.ExecuteCommand != "" {
 		for _, val := range v.AsList() {
 			_, err := terminal.Shellf(args.ExecuteCommand, val)
-			if err == terminal.ErrShellCommand {
+			if err != nil {
 				log.Fatal(err)
 			}
-			log.Panic(err)
 		}
 
 	}

--- a/main.go
+++ b/main.go
@@ -20,7 +20,10 @@ func main() {
 	args := internal.CliArgs{}
 	args.ParseFlags()
 
-	v := version.Version{}
+	v := version.Version{
+		Prefix: args.Prefix,
+		Suffix: args.Suffix,
+	}
 	if args.CustomVersion == internal.EmptyStringFlag {
 		v.GetLatestFromGit()
 	} else {

--- a/pkg/git/config.go
+++ b/pkg/git/config.go
@@ -27,7 +27,7 @@ func configureUserName() {
 
 	_, err = terminal.Shellf(`git config --global user.name "%s"`, gitUser)
 	if err != nil {
-		output.Debug(err)
+		log.Fatal(err)
 	}
 }
 
@@ -44,7 +44,7 @@ func configureUserEmail() {
 	}
 	_, err = terminal.Shellf(`git config --global user.email "%s"`, gitEmail)
 	if err != nil {
-		output.Debug(err)
+		log.Fatal(err)
 	}
 }
 

--- a/pkg/git/config.go
+++ b/pkg/git/config.go
@@ -16,37 +16,25 @@ func TryConfigureIdentity() {
 func configureUserName() {
 	gitUser, err := terminal.GetEnv("CI_GIT_USERNAME")
 	if err != nil {
-		if err == terminal.ErrEnvVarNotFound {
-			output.Debug(err)
-			return
-		}
-		log.Panic(err)
+		output.Debug(err)
+		return
 	}
 
 	_, err = terminal.Shellf(`git config --global user.name "%s"`, gitUser)
 	if err != nil {
-		if err == terminal.ErrShellCommand {
-			output.Debug(err)
-		}
-		log.Panic(err)
+		output.Debug(err)
 	}
 }
 
 func configureUserEmail() {
 	gitEmail, err := terminal.GetEnv("CI_GIT_EMAIL")
 	if err != nil {
-		if err == terminal.ErrEnvVarNotFound {
-			output.Debug(err)
-			return
-		}
-		log.Panic(err)
+		output.Debug(err)
+		return
 	}
 	_, err = terminal.Shellf(`git config --global user.email "%s"`, gitEmail)
 	if err != nil {
-		if err == terminal.ErrShellCommand {
-			output.Debug(err)
-		}
-		log.Panic(err)
+		output.Debug(err)
 	}
 }
 

--- a/pkg/git/config.go
+++ b/pkg/git/config.go
@@ -14,6 +14,11 @@ func TryConfigureIdentity() {
 }
 
 func configureUserName() {
+	_, err := terminal.Shell("git config --list | grep 'user.name'")
+	if err == nil {
+		return
+	}
+
 	gitUser, err := terminal.GetEnv("CI_GIT_USERNAME")
 	if err != nil {
 		output.Debug(err)
@@ -27,6 +32,11 @@ func configureUserName() {
 }
 
 func configureUserEmail() {
+	_, err := terminal.Shell("git config --list | grep 'user.email'")
+	if err == nil {
+		return
+	}
+
 	gitEmail, err := terminal.GetEnv("CI_GIT_EMAIL")
 	if err != nil {
 		output.Debug(err)

--- a/pkg/git/config.go
+++ b/pkg/git/config.go
@@ -4,8 +4,51 @@ import (
 	"log"
 	"os"
 
+	"semtag/pkg/output"
 	"semtag/pkg/terminal"
 )
+
+func TryConfigureIdentity() {
+	configureUserEmail()
+	configureUserName()
+}
+
+func configureUserName() {
+	gitUser, err := terminal.GetEnv("CI_GIT_USERNAME")
+	if err != nil {
+		if err == terminal.ErrEnvVarNotFound {
+			output.Debug(err)
+			return
+		}
+		log.Panic(err)
+	}
+
+	_, err = terminal.Shellf(`git config --global user.name "%s"`, gitUser)
+	if err != nil {
+		if err == terminal.ErrShellCommand {
+			output.Debug(err)
+		}
+		log.Panic(err)
+	}
+}
+
+func configureUserEmail() {
+	gitEmail, err := terminal.GetEnv("CI_GIT_EMAIL")
+	if err != nil {
+		if err == terminal.ErrEnvVarNotFound {
+			output.Debug(err)
+			return
+		}
+		log.Panic(err)
+	}
+	_, err = terminal.Shellf(`git config --global user.email "%s"`, gitEmail)
+	if err != nil {
+		if err == terminal.ErrShellCommand {
+			output.Debug(err)
+		}
+		log.Panic(err)
+	}
+}
 
 func TrySetGitCredentialsBasicAuth() {
 	gitUsername, isGitUser := os.LookupEnv("GIT_USERNAME")

--- a/pkg/output/main.go
+++ b/pkg/output/main.go
@@ -18,7 +18,7 @@ func Debug(v ...interface{}) {
 		log.Println(v...)
 	}
 }
-func DebugF(format string, v ...interface{}) {
+func Debugf(format string, v ...interface{}) {
 	Debug(fmt.Sprintf(format, v...))
 }
 
@@ -26,6 +26,6 @@ func Info(v ...interface{}) {
 	log.Println(v...)
 }
 
-func InfoF(format string, v ...interface{}) {
+func Infof(format string, v ...interface{}) {
 	Info(fmt.Sprintf(format, v...))
 }

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -24,7 +24,7 @@ func Test_Increment(t *testing.T) {
 	for _, tb := range tables {
 		t.Run("Test Increment", func(t *testing.T) {
 			ver := Version{}
-			ver.Parse(tb.ver)
+			ver.Load(tb.ver)
 			ver.Increment(tb.scope)
 			got := ver.String()
 			assertCorrectMessage(t, got, tb.want, tb.scope)
@@ -40,10 +40,8 @@ func Test_AsList(t *testing.T) {
 		{"g3ed223b", []string{"0.2.1-g3ed223b", "0.2.1", "0.2", "0"}},
 	}
 
-	ver := Version{
-		UseGit: true,
-	}
-	ver.Parse("0.2.1")
+	ver := Version{}
+	ver.Load("0.2.1")
 	for _, tb := range tables {
 		ver.Hash = tb.gitSha
 		actualList := ver.AsList()
@@ -75,7 +73,7 @@ func Test_String(t *testing.T) {
 		ver := Version{}
 		ver.Prefix = tb.prefix
 		ver.Suffix = tb.suffix
-		ver.Parse(vNumber)
+		ver.Load(vNumber)
 		if tb.expectedOutput != ver.String() {
 			t.Errorf("expected %v but found %v", tb.expectedOutput, ver.String())
 		}


### PR DESCRIPTION
Control whether a git tag should be created by using the `-path` flag, which can be used multiple times.

* Code refactoring